### PR TITLE
Stop SHA errors related to: Token Length Exception

### DIFF
--- a/dist/jsOTP-es5.js
+++ b/dist/jsOTP-es5.js
@@ -50,6 +50,9 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 					bits += this.leftpad(val.toString(2), 5, "0");
 					i++;
 				}
+				for (i = i % 8; i > 0; i--) {
+					bits += this.leftpad('0', 5, '0');
+			        }
 				i = 0;
 				while (i + 4 <= bits.length) {
 					chunk = bits.substr(i, 4);

--- a/dist/jsOTP.js
+++ b/dist/jsOTP.js
@@ -31,6 +31,9 @@
         bits += this.leftpad(val.toString(2), 5, "0");
         i++;
       }
+      for (i = i % 8; i > 0; i--) {
+	bits += this.leftpad('0', 5, '0');
+      }
       i = 0;
       while (i + 4 <= bits.length) {
         chunk = bits.substr(i, 4);


### PR DESCRIPTION
Some websites and providers generate a secret key that technically is not the proper length to use in generating a OTP. If you pad from the left when such a secret key is detected you can fix the key length without altering the output. This is needed for example with websites like Amazon that currently return a 52 character secret key.

NOTE: This changes was only done in the `jsOTP-es5.js` and `jsOTP.js` files. These files still need to be minified and then minified gzipped.