### PR TITLE
Fix for secrets where we have odd number of hex digits. For example Amazon.com totp secrets.

### DIFF
--- a/coffee/jsOTP.coffee
+++ b/coffee/jsOTP.coffee
@@ -22,7 +22,7 @@ class Totp
       bits += @leftpad(val.toString(2), 5, "0")
       i++
   
-  	checklength = bits.length - bits.length % 8
+    checklength = bits.length - bits.length % 8
     i = 0
     while i + 4 <= checklength
       chunk = bits.substr(i, 4)

--- a/coffee/jsOTP.coffee
+++ b/coffee/jsOTP.coffee
@@ -22,8 +22,9 @@ class Totp
       bits += @leftpad(val.toString(2), 5, "0")
       i++
   
+  	checklength = bits.length - bits.length % 8
     i = 0
-    while i + 4 <= bits.length
+    while i + 4 <= checklength
       chunk = bits.substr(i, 4)
       hex = hex + parseInt(chunk, 2).toString(16)
       i += 4


### PR DESCRIPTION
Multiple totp generators work because they ignore the last odd hex digit.
This should also be able to handle this.