### PR TITLE
fix bug for epic key

### DIFF
--- a/dist/jsOTP-es5.js
+++ b/dist/jsOTP-es5.js
@@ -76,6 +76,7 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 				epoch = Math.round(now / 1000.0);
 				time = this.leftpad(this.dec2hex(Math.floor(epoch / this.expiry)), 16, "0");
 				shaObj = new jsSHA("SHA-1", "HEX");
+				if (key.length % 2 !== 0) key = key.substring(0,key.length-1);
 				shaObj.setHMACKey(key, "HEX");
 				shaObj.update(time);
 				hmac = shaObj.getHMAC("HEX");

--- a/dist/jsOTP.js
+++ b/dist/jsOTP.js
@@ -53,6 +53,7 @@
       epoch = Math.round(now / 1000.0);
       time = this.leftpad(this.dec2hex(Math.floor(epoch / this.expiry)), 16, "0");
       shaObj = new jsSHA("SHA-1", "HEX");
+      if (key.length % 2 !== 0) key = key.substring(0,key.length-1);
       shaObj.setHMACKey(key, "HEX");
       shaObj.update(time);
       hmac = shaObj.getHMAC("HEX");

--- a/js/jsOTP.js
+++ b/js/jsOTP.js
@@ -53,6 +53,7 @@
       epoch = Math.round(now / 1000.0);
       time = this.leftpad(this.dec2hex(Math.floor(epoch / this.expiry)), 16, "0");
       shaObj = new jsSHA("SHA-1", "HEX");
+      if (key.length % 2 !== 0) key = key.substring(0,key.length-1);
       shaObj.setHMACKey(key, "HEX");
       shaObj.update(time);
       hmac = shaObj.getHMAC("HEX");


### PR DESCRIPTION
totp key for epic like `IZIEIWKUIFMVCTKFI5LUQVKZGZDEQUCSG5DFMUSWJRLEQWCUINGQ`
will throw error `String of HEX type must be in byte increments`
so I fix it